### PR TITLE
prevent terminal CTRL-characters in Eclipse console

### DIFF
--- a/plugins/info.evanchik.eclipse.karaf.ui/src/main/java/info/evanchik/eclipse/karaf/ui/KarafLaunchConfigurationInitializer.java
+++ b/plugins/info.evanchik.eclipse.karaf.ui/src/main/java/info/evanchik/eclipse/karaf/ui/KarafLaunchConfigurationInitializer.java
@@ -307,6 +307,11 @@ public class KarafLaunchConfigurationInitializer extends OSGiLaunchConfiguration
             vmArgs.append(" -Dosgi.noShutdown=true"); //$NON-NLS-1$
         }
 
+        // prevent terminal CTRL-characters in Eclipse console
+        if (vmArgs.indexOf("-Djline.terminal") == -1) { //$NON-NLS-1$
+            vmArgs.append(" -Djline.terminal=jline.UnsupportedTerminal"); //$NON-NLS-1$
+        }
+
         configuration.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, vmArgs.toString());
 
     }


### PR DESCRIPTION
Add -Djline.terminal=jline.UnsupportedTerminal to launch configuration. Without this EIK is barely usable on windows. Karaf shuts down immediately when launched from Eclipse.
